### PR TITLE
Fix state management and timer disposal

### DIFF
--- a/lib/Screens/ProfileScreen.dart
+++ b/lib/Screens/ProfileScreen.dart
@@ -12,9 +12,10 @@ class Profilescreen extends StatefulWidget {
 }
 
 class _ProfileScreenState extends State<Profilescreen> {
+  bool isSwitched = false;
+
   @override
   Widget build(BuildContext context) {
-    bool isSwitched = false;
 
     return Scaffold(
       backgroundColor: Colors.grey.shade200,

--- a/lib/Screens/SplachScreen.dart
+++ b/lib/Screens/SplachScreen.dart
@@ -12,10 +12,12 @@ class Splachscreen extends StatefulWidget {
 }
 
 class _SplachscreenState extends State<Splachscreen> {
+  Timer? _timer;
+
   @override
   void initState() {
     super.initState();
-    Timer(const Duration(milliseconds: 2300), () {
+    _timer = Timer(const Duration(milliseconds: 2300), () {
       Navigator.of(context)
           .push(MaterialPageRoute(builder: (ctx) => Authscreen()));
     });
@@ -23,6 +25,7 @@ class _SplachscreenState extends State<Splachscreen> {
 
   @override
   void dispose() {
+    _timer?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- preserve dark mode toggle state in profile screen
- ensure splash screen timer is cancelled on dispose

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f38f7ceb4832d998b15488749934e